### PR TITLE
GitHub Actions上でgem install権限エラーを解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          gem install bundler
+          gem install bundler --user-install
           bundle install --jobs 4 --retry 3
 
       - name: Deploy to Heroku


### PR DESCRIPTION
### 変更内容
・GitHub Actions上でgem install権限エラーを解消

### 確認して欲しい点
・CI/CDが正常に完了するか（GitHub Actionsの動作確認）