### PR TITLE
HerokuデプロイジョブにBundlerのPATH設定を追加し、bundleコマンドエラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Install dependencies
         run: |
           gem install bundler --user-install
+          echo "$HOME/.local/share/gem/ruby/3.2.0/bin" >> $GITHUB_PATH
           bundle install --jobs 4 --retry 3
 
       - name: Deploy to Heroku


### PR DESCRIPTION
### 変更内容
・HerokuデプロイジョブにBundlerのPATH設定を追加し、bundleコマンドエラーを修正

### 確認してもらいたい点
・CI/CDが正常に完了するか（GitHub Actionsの動作確認）