### PR TITLE
GitHub ActionsのHerokuデプロイステップを軽量化（ENOBUFS対策）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,3 +87,6 @@ jobs:
           heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
           heroku_app_name: "jiro-map-app"
           heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          delay: 20
+        env:
+          HEROKU_DEBUG: 0


### PR DESCRIPTION
### 変更内容
GitHub Actions実行時に Error: spawnSync /bin/sh ENOBUFS が発生していたため、
Herokuデプロイステップを軽量化

### 確認していただきたい点
GitHub Actionsが正常に完走すること