### PR TITLE
CI/CDワークフローを軽量化し、HerokuデプロイをCLI方式に変更（ENOBUFS対策）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,7 @@ jobs:
           bundler-cache: true
 
       - name: Deploy to Heroku
-        uses: akhileshns/heroku-deploy@v3.12.13
-        with:
-          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
-          heroku_app_name: "jiro-map-app"
-          heroku_email: ${{ secrets.HEROKU_EMAIL }}
-          delay: 20
-        env:
-          HEROKU_DEBUG: 0
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+          heroku git:remote -a jiro-map-app
+          git push heroku main --force


### PR DESCRIPTION
### 変更内容
akhileshns/heroku-deploy を廃止し、Heroku CLI による直接デプロイに変更

### 確認していただきたい点
Herokuへ正常にデプロイされること