### PR TITLE
Heroku CLIのPATHを追加してコマンド未検出エラーを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
           ruby-version: 3.3.4
           bundler-cache: true
 
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+          echo "/usr/local/bin" >> $GITHUB_PATH
+      
       - name: Deploy to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
### 変更内容
Heroku CLIのPATHを追加してコマンド未検出エラーを修正

### 確認していただきたい点
Herokuへ正常にデプロイされること