### PR TITLE
Herokuデプロイ時のshallow cloneエラーを解消するためgit fetch --unshallowを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,10 @@ jobs:
         run: |
           curl https://cli-assets.heroku.com/install.sh | sh
           echo "/usr/local/bin" >> $GITHUB_PATH
-      
+
+      - name: Unshallow the repository
+        run: git fetch --unshallow
+
       - name: Deploy to Heroku
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}


### PR DESCRIPTION
### 変更内容
Herokuデプロイ時のshallow cloneエラーを解消するためgit fetch --unshallowを追加

### 確認していただきたい点
Herokuへ正常にデプロイできること